### PR TITLE
python3.9-grpcio: bump to 1.64.0

### DIFF
--- a/tur-pypi-39/python3.9-grpcio/build.sh
+++ b/tur-pypi-39/python3.9-grpcio/build.sh
@@ -3,10 +3,10 @@ TERMUX_PKG_DESCRIPTION="High performance, open source, general RPC framework tha
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
 TERMUX_PKG_SRCURL=git+https://github.com/grpc/grpc
-TERMUX_PKG_VERSION="1.63.0"
+TERMUX_PKG_VERSION="1.64.0"
 TERMUX_PKG_DEPENDS="ca-certificates, libc++, openssl, python3.9, zlib"
 TERMUX_PKG_BUILD_DEPENDS="python3.9-cross"
-TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, 'setuptools==65.4.1', 'Cython<3'"
+TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, setuptools, 'Cython>=3.0.0'"
 TERMUX_PKG_BUILD_IN_SRC=true
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_TAG_TYPE="latest-release-tag"

--- a/tur-pypi-39/python3.9-grpcio/src-core-lib-gpr-tmpfile_posix.cc.patch
+++ b/tur-pypi-39/python3.9-grpcio/src-core-lib-gpr-tmpfile_posix.cc.patch
@@ -6,6 +6,6 @@
  
 -  gpr_asprintf(&filename_template, "/tmp/%s_XXXXXX", prefix);
 +  gpr_asprintf(&filename_template, "@TERMUX_PREFIX@/tmp/%s_XXXXXX", prefix);
-   GPR_ASSERT(filename_template != nullptr);
+   CHECK_NE(filename_template, nullptr);
  
    fd = mkstemp(filename_template);


### PR DESCRIPTION
Closes #86 