### PR TITLE
python3.11-pycryptodomex: bump to 3.21.0

### DIFF
--- a/tur-pypi-311/python3.11-pycryptodomex/build.sh
+++ b/tur-pypi-311/python3.11-pycryptodomex/build.sh
@@ -1,10 +1,11 @@
 TERMUX_PKG_HOMEPAGE=https://www.pycryptodome.org/
 TERMUX_PKG_DESCRIPTION="A self-contained Python package of low-level cryptographic primitives"
 TERMUX_PKG_LICENSE="BSD 2-Clause, Public Domain"
+TERMUX_PKG_LICENSE_FILE="LICENSE.rst"
 TERMUX_PKG_MAINTAINER="@termux-user-repository"
-TERMUX_PKG_VERSION="3.20.0"
+TERMUX_PKG_VERSION="3.21.0"
 TERMUX_PKG_SRCURL="https://github.com/Legrandin/pycryptodome/archive/refs/tags/v${TERMUX_PKG_VERSION}x.tar.gz"
-TERMUX_PKG_SHA256=6bc506460da0952593c4de095f7cffe926a541336afb6dffcc2ab2cb315cc35b
+TERMUX_PKG_SHA256=7762d1b658b47e989f21ed844a8bf9a527b130fecec26f0d5076656dc38c0558
 TERMUX_PKG_DEPENDS="python3.11"
 TERMUX_PKG_PYTHON_COMMON_DEPS="wheel, 'setuptools==67.8.0'"
 TERMUX_PKG_BUILD_IN_SRC=true
@@ -36,6 +37,6 @@ termux_step_make_install() {
 }
 
 termux_step_post_make_install() {
-	mv ./dist/pycryptodomex-$TERMUX_PKG_VERSION-cp35-abi3-linux_$TERMUX_ARCH.whl \
+	mv ./dist/pycryptodomex-$TERMUX_PKG_VERSION-cp36-abi3-linux_$TERMUX_ARCH.whl \
 		./dist/pycryptodomex-$TERMUX_PKG_VERSION-cp311-cp311-linux_$TERMUX_ARCH.whl
 }


### PR DESCRIPTION
Closes #123 